### PR TITLE
Add .gitignore file to default config files created by `eos start`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ The following file tree is generated:
   + frontend/
     + actions/
     + components/
+      app.jsx
       root.jsx
+      router.jsx
     + middleware/
       master_middleware.js
     + reducers/
@@ -47,8 +49,11 @@ The following file tree is generated:
     + store/
       store.js
     + util/
-    index.jsx
-  webpack.config.js
+      index.jsx
+    .gitignore
+    index.html  
+    package.json
+    webpack.config.js
 ```
 Along with the creation of the file structure comes the installation of all dependencies needed.
 

--- a/eos-cli/actions/actions.js
+++ b/eos-cli/actions/actions.js
@@ -29,7 +29,7 @@ const start = (name) => {
       Start.createStartFile(`index.jsx`, `${name}/frontend/`);
     Start.createStartFile(`../webpack.config.js`, `${name}/`);
     Start.createStartFile(`../package.json`, `${name}/`);
-
+    Start.createStartFile(`../.gitignore`, `${name}/`);
   Start.installDependencies(name);
 };
 

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+bundle.js
+bundle.js.map


### PR DESCRIPTION
`eos start` now creates a default .gitignore file in project directory:

```
#./templates/.gitignore
node_modules/
bundle.js
bundle.js.map
```

Adds action to create file when `eos start` is invoked:

```
#./eos-cli/actions/actions.js:32
Start.createStartFile(`../.gitignore`, `${name}/`);
```
