### PR TITLE
add jquery to index.html

### DIFF
--- a/templates/start/index.html
+++ b/templates/start/index.html
@@ -3,9 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title></title>
-    
     <script type="application/javascript" src="bundle.js"></script>
-
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
   </head>
   <body>
 


### PR DESCRIPTION
Adds script tag in head of `templates/start/index.html` to add Google CDN version of minified jquery.   
