### PR TITLE
add warning for users of npm to cd into directory and run npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The following file tree is generated:
     webpack.config.js
 ```
 Along with the creation of the file structure comes the installation of all dependencies needed.
+WARNING:  NVM users will need to run the following commands to install dependencies:
+```Bash
+cd [name]
+npm install
+```
 
 All the first level dependencies included are:
 

--- a/eos-cli/actions/action_helpers/start.js
+++ b/eos-cli/actions/action_helpers/start.js
@@ -26,6 +26,9 @@ const installDependencies = (name) => {
   let install = Util.exec(`cd ${name} && npm install`);
   install.on('close', (code) => {
     console.log(`Done`);
+    console log(`IF YOU USE NVM RUN THE FOLLOWING COMMANDS:`);
+    console log(`cd ${name}`);
+    console log(`npm install`);
   });
 };
 


### PR DESCRIPTION
Adds warning in README and in command line for users of NVM to install dependencies in project folder with `npm install` to get up and running.
