### PR TITLE
fix .gitignore issue with nvm

### DIFF
--- a/eos-cli/actions/actions.js
+++ b/eos-cli/actions/actions.js
@@ -28,7 +28,8 @@ const start = (name) => {
         Start.createStartFile(`store.js`, `${name}/frontend/store/`);
       Start.createDir(`util`, `${name}/frontend/`);
       Start.createStartFile(`index.jsx`, `${name}/frontend/`);
-    Start.createStartFile(`../.gitignore`, `${name}/`);
+    //creates .gitignore from command line to solve nvm issue
+    Util.exec(`cd ${name} && echo 'node_modules/\nbundle.js\nbundle.js.map' >> .gitignore`);
 };
 
 const generate = (action, name) => {

--- a/templates/.gitignore
+++ b/templates/.gitignore
@@ -1,3 +1,0 @@
-node_modules/
-bundle.js
-bundle.js.map


### PR DESCRIPTION
Fixes issue #6.  Replaces template file with creation directly from command line:

``` JavaScript
//actions/actions.js:32
Util.exec(`cd ${name} && echo 'node_modules/\nbundle.js\nbundle.js.map' >> .gitignore`);
```

 to fix issue with name change from .gitignore to .npmignore when installing eos on a machine running nvm.  
