### PR TITLE
Add `eos generate service [type] [name]` to generate modular servers

### DIFF
--- a/eos-cli/actions/action_helpers/env_config.js
+++ b/eos-cli/actions/action_helpers/env_config.js
@@ -1,0 +1,17 @@
+const Util = require('../../util/util.js');
+const Servers = require(`../../../templates/servers/servers.js`)
+
+const express = (name) => {
+  Util.exec(`
+    cd ${name} \
+    && echo "${Servers.express()}" >> ${name}.js \
+    && npm init --yes \
+    && npm install --save express \
+  `);
+}
+
+const Config = {
+  express: express
+};
+
+module.exports = Config;

--- a/eos-cli/actions/action_helpers/generate.js
+++ b/eos-cli/actions/action_helpers/generate.js
@@ -1,5 +1,6 @@
 const Start = require('./start.js');
 const Util = require('../../util/util.js');
+const Config = require('./env_config.js')
 
 //// Generate Helpers ////
 let command = '';
@@ -87,6 +88,14 @@ const server = (name, type) => {
     Start.installDependencies);
 };
 
+const generateService = (type, name) => {
+  // Util.exec(`mkdir ${name} && cd ${name} && touch ${type}.js`);
+  Util.exec(`mkdir ${name}`);
+  Config[type](name);
+  // Util.exec(`cd ${type} && touch ${name}.js`);
+}
+
+
 //APPEND
 const append = (name, type) => {
   const masterFile = type === "middleware" ? "master_middleware" : "root_reducer";
@@ -118,6 +127,7 @@ let Generate = {
   generateComponent: generateComponent,
   setComponentNames: setComponentNames,
   server: server,
+  generateService: generateService,
   append: append
 };
 

--- a/eos-cli/actions/actions.js
+++ b/eos-cli/actions/actions.js
@@ -31,7 +31,7 @@ const start = (name) => {
     Start.createStartFile(`../.gitignore`, `${name}/`);
 };
 
-const generate = (action, name) => {
+const generate = (action, name, ...args) => {
   let cycle = (action === 'cycle');
   if (action === 'component' || cycle) {
     // Component
@@ -59,6 +59,11 @@ const generate = (action, name) => {
     // Util
     Generate.generateFile(name, 'api_util', 'js', './frontend/util/');
     Generate.setName(name, 'api_util');
+  }
+  if (action === 'service' || cycle) {
+    // Util
+    Generate.generateService(name, args[0]);
+    // Generate.setName(name, 'api_util');
   }
 };
 
@@ -90,8 +95,9 @@ const remove = (action, name) => {
 
 const server = () => {
   let run = Util.exec('node server/app.js');
-  run.stdout.on('data', (data)=>console.log(data));
+  run.stdout.on('data', (data) => console.log(data));
 };
+
 
 const help = () => {
   Help.display();

--- a/eos-cli/eos-cli.js
+++ b/eos-cli/eos-cli.js
@@ -10,8 +10,8 @@ const program = require('commander');
 let name, start;
 program
   .version('0.0.1')
-  .arguments('<cmd> [env1] [env2]')
-  .action(function (cmd, env1, env2) {
+  .arguments('<cmd> [env1] [env2] [env3]')
+  .action(function (cmd, env1, env2, env3) {
     // Start
     if (['start', 's'].includes(cmd)) {
       start = true;
@@ -20,7 +20,7 @@ program
     }
     // Generate
     else if (['generate', 'g'].includes(cmd)) {
-      Actions.generate(env1, env2);
+      Actions.generate(env1, env2, env3);
     }
     // Remove
     else if (['remove', 'rm'].includes(cmd)) {

--- a/templates/servers/servers.js
+++ b/templates/servers/servers.js
@@ -1,0 +1,24 @@
+const express = () => {
+  return `const express = require('express');
+const app = express();
+
+app.get('/', function(req, res){
+  console.log('Hello.  Node Server is running');
+  res.send('Hello.  Node Server is running');
+});
+
+if (module === require.main) {
+  var server = app.listen(process.env.PORT || 8000, function () {
+    var port = server.address().port;
+    console.log('Node Server listening on port %s', port);
+  });
+}
+
+module.exports = server;`
+};
+
+const Servers = {
+  express: express
+};
+
+module.exports = Servers


### PR DESCRIPTION
In project directory running `eos generate service [type] [name]` will generate a server and set up independent environment in it's own directory.  Currently only supported type is `express`.  Does not interfere with current functionality but could easily be added as default to deprecate current setup later.   
