### PR TITLE
URGENT MERGE ASAP: conflict in code breaks eos start

### DIFF
--- a/eos-cli/actions/action_helpers/generate.js
+++ b/eos-cli/actions/action_helpers/generate.js
@@ -101,12 +101,12 @@ const generateService = (type, name, path, defaultServer=false) => {
   }
 };
 
-<<<<<<< HEAD
+//<<<<<<< HEAD
 //APPEND
-=======
+//=======
 
 // Append to Master Files
->>>>>>> master
+//>>>>>>> master
 const append = (name, type) => {
   const masterFile = type === "middleware" ? "master_middleware" : "root_reducer";
   const appliedFile = type === "middleware"


### PR DESCRIPTION
Left git conflict unresolved in `eos-cli/actions/action_helpers/generate.js:104`.   Throws syntax error on `eos start` :

``` JavaScript
<<<<<<< HEAD
//APPEND
=======

// Append to Master Files
>>>>>>> master
```

Have just commented out for now just two comments affected can resolve later. 
